### PR TITLE
Fix compatibility with org-journal

### DIFF
--- a/org-habit-stats.el
+++ b/org-habit-stats.el
@@ -671,7 +671,8 @@ HABIT-DATA contains the results of `org-habit-parse-todo`."
            (month (1- (calendar-extract-month date)))
            (year (calendar-extract-year date))
            (completed-dates (nth 4 habit-data)))
-      (calendar-generate-window month year)
+      (let (calendar-today-visible-hook calendar-today-invisible-hook)
+        (calendar-generate-window month year))
       (setq org-habit-stats-displayed-month month)
       (setq org-habit-stats-displayed-year year)
       (org-habit-stats-calendar-mark-habits habit-data))
@@ -684,7 +685,8 @@ HABIT-DATA contains the results of `org-habit-parse-todo`."
          (habit-data org-habit-stats-current-habit-data))
     (with-current-buffer org-habit-stats-calendar-buffer
       (setq buffer-read-only nil)
-      (calendar-generate-window month year)
+      (let (calendar-today-visible-hook calendar-today-invisible-hook)
+        (calendar-generate-window month year))
       (org-habit-stats-calendar-mark-habits habit-data)
       (setq buffer-read-only t))))
 


### PR DESCRIPTION
[org-journal](https://github.com/bastibe/org-journal) and [org-roam](https://github.com/org-roam/org-roam) dailies functionality populate `calendar-today-visible-hook` and `calendar-today-invisible-hook`.

At least in the case of org-journal, this causes `calendar-generate-window` to crash, and it doesn't make much sense to mark journal entries in the habit stats buffer anyway.

So this sets both hooks to `nil` for running `calendar-generate-window`.